### PR TITLE
feat: implement cleaner output with color-coded table format

### DIFF
--- a/packages/next-broken-links/src/index.ts
+++ b/packages/next-broken-links/src/index.ts
@@ -4,7 +4,7 @@ import { debug, error, success, withProgress } from "./logger";
 import { crawlNextOutput, crawlPublicAssets } from "./next/crawler";
 import { extractLinks } from "./next/extract";
 import parseNextConfig from "./next/parse-next-config";
-import { checkValidLinks } from "./next/validate-links";
+import { checkValidLinks, printBrokenLinksTable } from "./next/validate-links";
 
 const program = new Command()
 	.name(name)
@@ -68,9 +68,7 @@ const main = async () => {
 
 	if (result.length) {
 		console.log(`${error} Found ${result.length} broken links`);
-		for (const link of result) {
-			console.log(`\t${link.file}: ${link.link}`);
-		}
+		printBrokenLinksTable(result, config);
 		process.exit(1);
 	} else {
 		console.log(`${success} No broken links found`);

--- a/packages/next-broken-links/src/next/extract.ts
+++ b/packages/next-broken-links/src/next/extract.ts
@@ -8,7 +8,7 @@ import type { ExtendedNextConfig } from "./parse-next-config";
 const LINK_REGEX = /<a[^>]+href="([^"]+)"/g;
 
 interface Link {
-	type: "link";
+	type: "link" | "image";
 	value: string;
 }
 


### PR DESCRIPTION
Implements cleaner output for broken links with:

- Group broken links by source file
- Map HTML files back to TSX source files
- Color-coded table format with icons
- Alphabetical sorting for consistency

Fixes #9

Generated with [Claude Code](https://claude.ai/code)