### PR TITLE
feat: add --no-config mode with --output and --distDir options

### DIFF
--- a/.changeset/wicked-friends-hug.md
+++ b/.changeset/wicked-friends-hug.md
@@ -1,0 +1,5 @@
+---
+"@vahor/next-broken-links": minor
+---
+
+add --no-config mode with --output and --distDir options

--- a/packages/next-broken-links/README.md
+++ b/packages/next-broken-links/README.md
@@ -66,6 +66,19 @@ If you have broken links, it will output the following:
 - `--no-config` - Skip parsing next.config file and use provided options.
   - Useful to avoid installing dependencies present in next.config.js (e.g., contentlayer).
 
+#### Example
+
+```bash
+# For static export without parsing config
+bunx @vahor/next-broken-links --no-config --output export
+
+# For standard build with custom dist directory
+bunx @vahor/next-broken-links --no-config --distDir custom-dist
+
+# For static export with custom dist directory
+bunx @vahor/next-broken-links --no-config --output export --distDir custom-out
+```
+
 # Who is using this?
 
 - [vahor.fr](https://vahor.fr/project/next-broken-links) [(source)](https://github.com/Vahor/vahor.fr/blob/main/package.json)

--- a/packages/next-broken-links/README.md
+++ b/packages/next-broken-links/README.md
@@ -59,6 +59,12 @@ If you have broken links, it will output the following:
 - `--domain <domain>` - Domain to check links against. 
   - If not set, non relative links will be ignored.
 - `--verbose` - Enable verbose mode.
+- `--output <type>` - Output type: 'export' for static export, undefined for standard build.
+  - Only used when `--no-config` is specified.
+- `--distDir <path>` - Custom dist directory path.
+  - Only used when `--no-config` is specified.
+- `--no-config` - Skip parsing next.config file and use provided options.
+  - Useful to avoid installing dependencies present in next.config.js (e.g., contentlayer).
 
 # Who is using this?
 

--- a/packages/next-broken-links/src/index.ts
+++ b/packages/next-broken-links/src/index.ts
@@ -4,7 +4,7 @@ import { name, version } from "../package.json" assert { type: "json" };
 import { debug, error, success, withProgress } from "./logger";
 import { crawlNextOutput, crawlPublicAssets } from "./next/crawler";
 import { extractLinks } from "./next/extract";
-import parseNextConfig, { type ExtendedNextConfig } from "./next/parse-next-config";
+import parseNextConfig, { createFallbackConfig, type ExtendedNextConfig } from "./next/parse-next-config";
 import { checkValidLinks } from "./next/validate-links";
 
 const program = new Command()
@@ -23,32 +23,6 @@ program.parse();
 const options = program.opts();
 process.env.DEBUG = options.verbose ? "1" : "";
 export type Options = typeof options;
-
-const createFallbackConfig = (options: Options): ExtendedNextConfig => {
-	const cwd = process.cwd();
-	const output = options.output === "export" ? "export" : undefined;
-	let outputDir: string;
-	
-	if (options.distDir) {
-		outputDir = join(cwd, options.distDir);
-		if (output !== "export") {
-			outputDir = join(outputDir, "server", "app");
-		}
-	} else if (output === "export") {
-		outputDir = join(cwd, "out");
-	} else {
-		outputDir = join(cwd, ".next", "server", "app");
-	}
-
-	return {
-		output,
-		distDir: options.distDir || (output === "export" ? "out" : ".next"),
-		_vahor: {
-			outputDir,
-			root: cwd,
-		},
-	};
-};
 
 const main = async () => {
 	let config: ExtendedNextConfig;

--- a/packages/next-broken-links/src/index.ts
+++ b/packages/next-broken-links/src/index.ts
@@ -1,10 +1,12 @@
-import { join } from "node:path";
 import { Command } from "@commander-js/extra-typings";
 import { name, version } from "../package.json" assert { type: "json" };
 import { debug, error, success, withProgress } from "./logger";
 import { crawlNextOutput, crawlPublicAssets } from "./next/crawler";
 import { extractLinks } from "./next/extract";
-import parseNextConfig, { createFallbackConfig, type ExtendedNextConfig } from "./next/parse-next-config";
+import parseNextConfig, {
+	createFallbackConfig,
+	type ExtendedNextConfig,
+} from "./next/parse-next-config";
 import { checkValidLinks } from "./next/validate-links";
 
 const program = new Command()
@@ -14,20 +16,26 @@ const program = new Command()
 	.option("-c, --config <path>", "next.config.js path")
 	.option("--domain <domain>", "Domain to check links against")
 	.option("-v, --verbose", "Enable verbose mode")
-	.option("--output <type>", "Output type: 'export' for static export, undefined for standard build")
+	.option(
+		"--output <type>",
+		"Output type: 'export' for static export, undefined for standard build",
+	)
 	.option("--distDir <path>", "Custom dist directory path")
-	.option("--no-config", "Skip parsing next.config file and use provided options");
+	.option(
+		"--no-config",
+		"Skip parsing next.config file and use provided options",
+	);
 
 program.parse();
 
 const options = program.opts();
 process.env.DEBUG = options.verbose ? "1" : "";
-export type Options = typeof options;
+export type CliOptions = typeof options;
 
 const main = async () => {
 	let config: ExtendedNextConfig;
-	
-	if (options.noConfig) {
+
+	if (options.config === false) {
 		debug("Skipping next.config parsing due to --no-config flag");
 		config = createFallbackConfig(options);
 		debug(`Using fallback config: ${JSON.stringify(config, null, 2)}`);

--- a/packages/next-broken-links/src/next/extract.ts
+++ b/packages/next-broken-links/src/next/extract.ts
@@ -1,9 +1,8 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { XMLParser } from "fast-xml-parser";
-import type { Options } from "..";
 import { debug } from "../logger";
-import type { ExtendedNextConfig } from "./parse-next-config";
+import type { ExtendedNextConfig, Options } from "./parse-next-config";
 
 const LINK_REGEX = /<a[^>]+href="([^"]+)"/g;
 

--- a/packages/next-broken-links/src/next/extract.ts
+++ b/packages/next-broken-links/src/next/extract.ts
@@ -1,8 +1,9 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { XMLParser } from "fast-xml-parser";
+import type { CliOptions } from "..";
 import { debug } from "../logger";
-import type { ExtendedNextConfig, Options } from "./parse-next-config";
+import type { ExtendedNextConfig } from "./parse-next-config";
 
 const LINK_REGEX = /<a[^>]+href="([^"]+)"/g;
 
@@ -74,7 +75,7 @@ export const extractFromSitemap = (xml: string, domain?: string): Link[] => {
 export const extractLinks = async (
 	filePath: string,
 	config: ExtendedNextConfig,
-	options: Options,
+	options: CliOptions,
 ): Promise<Links> => {
 	const fullPath = join(config._vahor.outputDir, filePath);
 	if (fullPath.endsWith(".html")) {

--- a/packages/next-broken-links/src/next/parse-next-config.ts
+++ b/packages/next-broken-links/src/next/parse-next-config.ts
@@ -3,6 +3,15 @@ import { dirname, join } from "node:path";
 import type { NextConfig } from "next";
 import { debug, value } from "../logger";
 
+export interface Options {
+	config?: string;
+	domain?: string;
+	verbose?: boolean;
+	output?: string;
+	distDir?: string;
+	noConfig?: boolean;
+}
+
 export interface ExtendedNextConfig extends NextConfig {
 	_vahor: {
 		outputDir: string;
@@ -89,4 +98,30 @@ const checkSupportedConfiguration = (config: NextConfig) => {
 		);
 	}
 	return true;
+};
+
+export const createFallbackConfig = (options: Options): ExtendedNextConfig => {
+	const cwd = process.cwd();
+	const output = options.output === "export" ? "export" : undefined;
+	let outputDir: string;
+	
+	if (options.distDir) {
+		outputDir = join(cwd, options.distDir);
+		if (output !== "export") {
+			outputDir = join(outputDir, "server", "app");
+		}
+	} else if (output === "export") {
+		outputDir = join(cwd, "out");
+	} else {
+		outputDir = join(cwd, ".next", "server", "app");
+	}
+
+	return {
+		output,
+		distDir: options.distDir || (output === "export" ? "out" : ".next"),
+		_vahor: {
+			outputDir,
+			root: cwd,
+		},
+	};
 };


### PR DESCRIPTION
This allows running the tool without parsing next.config.js,
avoiding dependency installation issues with packages like contentlayer.

- Add --output option to specify output type ('export' for static export)
- Add --distDir option to specify custom dist directory path
- Add --no-config flag to skip next.config parsing entirely
- Create fallback config construction when --no-config is used
- Update documentation with new options and usage examples

Fixes #29

Generated with [Claude Code](https://claude.ai/code)